### PR TITLE
converted spelled-out links to anchor tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@
   * Click "Preview changes" to check your work.
   * Enter a short commit message in the textbox under the "Commit changes" heading.
   * Click the "Commit changes" button.
-* Create a pull request https://help.github.com/articles/using-pull-requests/
-  * Create a pull request to propose and collaborate on changes to a repository. 
+* Create a pull request (see Github's help guide <a href="https://help.github.com/articles/using-pull-requests/">here.</a>
+  * Create a pull request to propose and collaborate on changes to a repository.
   * Click the "New Pull Request" button.
 * Create a pull request from a forked repository https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
   * Navigate to the original repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ### Here's how to contribute:
 * Create a GitHub account if you don't have one.
-* Fork the repository = https://help.github.com/articles/fork-a-repo/
+* Fork the repository (see GitHub's help guide <a href="https://help.github.com/articles/fork-a-repo/">here</a>).
   * Click the Fork button in the upper right corner of the screen.
   * This will copy the repo to your account and you will then be in your copy of the repository.
 * Make some changes.
@@ -9,10 +9,10 @@
   * Click "Preview changes" to check your work.
   * Enter a short commit message in the textbox under the "Commit changes" heading.
   * Click the "Commit changes" button.
-* Create a pull request (see Github's help guide <a href="https://help.github.com/articles/using-pull-requests/">here.</a>
+* Create a pull request (see GitHub's help guide <a href="https://help.github.com/articles/using-pull-requests/">here</a>).
   * Create a pull request to propose and collaborate on changes to a repository.
   * Click the "New Pull Request" button.
-* Create a pull request from a forked repository https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
+* Create a pull request from a forked repository (see GitHub's help guide <a href="https://help.github.com/en/articles/creating-a-pull-request-from-a-fork">here</a>).
   * Navigate to the original repository
   * To the right of the branch drop down click new pull request
   * Click compare across forks


### PR DESCRIPTION
I converted three spelled-out links to GitHub help guides to anchor tags.